### PR TITLE
added new option for MCSessionSendDataMode

### DIFF
--- a/multipeer.py
+++ b/multipeer.py
@@ -274,11 +274,12 @@ class MultipeerConnectivity():
     self.advertiser.stopAdvertisingPeer()
     self.browser.stopBrowsingForPeers()
 
-  def send(self, message, to_peer=None):
+  def send(self, message, to_peer=None, reliable=True):
     ''' Send a message to some or all peers.
 
     * `message` - to be sent to the peer(s). Must be JSON-serializable.
     * `to_peer` - receiver peer IDs. Can be a single peer ID, a list of peer IDs, or left out (None) for sending to all connected peers.
+    * `reliable` - MCSessionSendDataMode. Can be True or False, or left out (True). Indicates whether delivery of data should be guaranteed.
     '''
     if type(to_peer) == list:
       peers = to_peer
@@ -286,7 +287,7 @@ class MultipeerConnectivity():
       peers = self.get_peers()
     else:
       peers = [to_peer]
-    self.session.sendData_toPeers_withMode_error_(json.dumps(message).encode(), peers, 0, None)
+    self.session.sendData_toPeers_withMode_error_(json.dumps(message).encode(), peers,  0 if reliable else 1, None)
 
   def receive(self, message, from_peer):
     ''' Override in a subclass to handle incoming messages. '''


### PR DESCRIPTION
Hi @mikaelho ,
I am using it for multipeer realtime games and trying to get the latency down with this a bit.

 I am seeing now ping response times between 8 to 300 ms with 30 Byte packets. Strange thing is that it is either around 8ms (which is very fast enough) or around 250ms (a bit to laggy) regardless of senddatamode. In fact the effect of send data mode seems at least with only two peers very minor. This might be another story if connected to 7 peers at once.
  
... this is still not enough for my taste ;-) and needs. Looking into the streaming thing now ...


all the best
mithrendal